### PR TITLE
First concept implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ npm install koa @koa/router koa-x-router joi
 ```
 
 ### with TypeScript
+
 ```shell
 npm install @types/koa @types/koa__router -D
 ```
@@ -44,15 +45,17 @@ router.add({
   path: "/users",
   validate: {
     query: Joi.object({
-        name: Joi.string(),
+      name: Joi.string(),
     }),
     output: {
-      200: Joi.array().items(
-        Joi.object({
-          name: Joi.string().required(),
-          age: Joi.number().positive().required(),
-        })
-      ),
+      200: {
+        body: Joi.array().items(
+          Joi.object({
+            name: Joi.string().required(),
+            age: Joi.number().positive().required(),
+          })
+        ),
+      },
     },
   },
   handler: async (ctx) => {
@@ -60,7 +63,7 @@ router.add({
   },
 });
 
-docRouter.get('/', (ctx) => {
+docRouter.get("/", (ctx) => {
   ctx.body = `<!DOCTYPE html>
   <html>
   <head>
@@ -78,11 +81,11 @@ docRouter.get('/', (ctx) => {
   </html>`;
 });
 
-docRouter.get('/openapi.json', (ctx) => {
+docRouter.get("/openapi.json", (ctx) => {
   ctx.body = router.generateOpenApiSpecJson({
     info: {
-      title: 'koa-x-router Demo API Docs',
-      version: '1.0.0',
+      title: "koa-x-router Demo API Docs",
+      version: "1.0.0",
     },
   });
 });
@@ -100,8 +103,10 @@ You can also implement your custom adapter by implementing the `XRouterAdaptor` 
 This allows you to use your preferred validation library for route validation.
 
 ## Contributing
+
 Contributions are welcome!
 If you have any suggestions, bug reports, or feature requests, please open an issue.
 
 ## License
+
 This project is licensed under the Apache License 2.0.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,71 @@
+# koa-x-router
+
+`koa-x-router` is a library that extends the functionality of `koa-router` by providing validation and automatic API documentation features. It simplifies the process of defining routes, validating request data, and generating API documentation.
+
+## Features
+
+- **Validation**: With `koa-x-router`, you can perform validation using various validation libraries. The library provides adapters such as `JoiAdaptor` and `YupAdaptor` that allow you to define validation schemas using popular validation libraries like `Joi` or `Yup`. You can also implement your own custom adapter by implementing the `XRouterAdaptor` interface.
+
+- **Automatic API Documentation**: `koa-x-router` automatically generates API documentation based on your route definitions. It extracts information about route paths, request methods, request/response data structures, and validation rules. The generated documentation can be accessed through an endpoint, making it convenient for developers to understand and consume your API.
+
+## Installation
+
+You can install koa-x-router using npm:
+
+```shell
+npm install koa koa-router koa-x-router joi
+```
+
+## Usage
+
+To use `koa-x-router`, import it and initialize it with an instance of `koa-router`. Here's a basic example:
+
+```ts
+import Koa from "koa";
+import bodyParser from "koa-bodyparser";
+import { Router, JoiAdaptor } from "koa-x-router";
+
+const app = new Koa();
+const router = new Router({
+  adaptors: [JoiAdaptor], // <== Important!
+});
+
+// Define a route with validation
+router.add({
+  method: "get",
+  path: "/users",
+  validate: {
+    query: Joi.object({
+        name: Joi.string(),
+    }),
+    output: {
+      200: Joi.array().items(
+        Joi.object({
+          name: Joi.string().required(),
+          age: Joi.number().positive().required(),
+        })
+      ),
+    },
+  },
+  handler: async (ctx) => {
+    // code...
+  },
+});
+
+app.use(bodyParser());
+app.use(router.routes());
+
+app.listen(3000, () => {
+  console.log("Server listening on port 3000");
+});
+```
+
+You can also implement your custom adapter by implementing the XRouterAdaptor interface.
+This allows you to use your preferred validation library for route validation.
+
+## Contributing
+Contributions are welcome!
+If you have any suggestions, bug reports, or feature requests, please open an issue.
+
+## License
+This project is licensed under the MIT License.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # koa-x-router
 
-`koa-x-router` is a library that extends the functionality of `koa-router` by providing validation and automatic API documentation features. It simplifies the process of defining routes, validating request data, and generating API documentation.
+`koa-x-router` is a library that extends the functionality of `@koa/router` by providing validation and automatic API documentation features. It simplifies the process of defining routes, validating request data, and generating API documentation.
 
 ## Features
 
@@ -13,12 +13,12 @@
 You can install koa-x-router using npm:
 
 ```shell
-npm install koa koa-router koa-x-router joi
+npm install koa @koa/router koa-x-router joi
 ```
 
 ## Usage
 
-To use `koa-x-router`, import it and initialize it with an instance of `koa-router`. Here's a basic example:
+To use `koa-x-router`, import it and initialize it with an instance of `@koa/router`. Here's a basic example:
 
 ```ts
 import Koa from "koa";

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ const app = new Koa();
 const router = new Router({
   adaptors: [JoiAdaptor], // <== Important!
 });
+const docRouter = new Router();
 
 // Define a route with validation
 router.add({
@@ -54,6 +55,34 @@ router.add({
   },
 });
 
+docRouter.get('/', (ctx) => {
+  ctx.body = `<!DOCTYPE html>
+  <html>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>API Documentation</title>
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+    <style>body{margin: 0;padding: 0;}</style>
+  </head>
+  <body>
+    <redoc spec-url='/openapi.json' lazy-rendering></redoc>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"></script>
+  </body>
+  </html>`;
+});
+
+docRouter.get('/openapi.json', (ctx) => {
+  ctx.body = router.generateOpenApiSpecJson({
+    info: {
+      title: 'koa-x-router Demo API Docs',
+      version: '1.0.0',
+    },
+  });
+});
+
+app.use(docRouter.routes());
 app.use(bodyParser());
 app.use(router.routes());
 
@@ -62,7 +91,7 @@ app.listen(3000, () => {
 });
 ```
 
-You can also implement your custom adapter by implementing the XRouterAdaptor interface.
+You can also implement your custom adapter by implementing the `XRouterAdaptor` interface.
 This allows you to use your preferred validation library for route validation.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install koa @koa/router koa-x-router joi
 
 ## Usage
 
-[Demo](https://stackblitz.com/edit/stackblitz-starters-mmprm1?file=index.ts)
+[Demo](https://stackblitz.com/edit/koa-x-router-demo?file=index.ts)
 
 To use `koa-x-router`, import it and initialize it with an instance of `@koa/router`. Here's a basic example:
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ You can install koa-x-router using npm:
 npm install koa @koa/router koa-x-router joi
 ```
 
+### with TypeScript
+```shell
+npm install @types/koa @types/koa__router -D
+```
+
 ## Usage
 
 [Demo](https://stackblitz.com/edit/koa-x-router-demo?file=index.ts)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ npm install koa @koa/router koa-x-router joi
 
 ## Usage
 
+[Demo](https://stackblitz.com/edit/stackblitz-starters-mmprm1?file=index.ts)
+
 To use `koa-x-router`, import it and initialize it with an instance of `@koa/router`. Here's a basic example:
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -68,4 +68,4 @@ Contributions are welcome!
 If you have any suggestions, bug reports, or feature requests, please open an issue.
 
 ## License
-This project is licensed under the MIT License.
+This project is licensed under the Apache License 2.0.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "koa-x-router",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "koa-x-router",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "joi-to-swagger": "^6.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "koa-x-router",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "koa-x-router",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "license": "Apache-2.0",
       "dependencies": {
         "joi-to-swagger": "^6.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,11 +39,11 @@
         "typescript": "^4.9.5"
       },
       "optionalDependencies": {
-        "joi": "^17.9.2"
+        "joi": ">=17.0.0"
       },
       "peerDependencies": {
         "@koa/router": ">=8.0.0",
-        "joi": ">=16.0.0",
+        "joi": ">=17.0.0",
         "koa": "*"
       },
       "peerDependenciesMeta": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,8 @@
         "@types/eslint": "^8",
         "@types/jest": "^29.5.2",
         "@types/koa": "^2.13.6",
-        "@types/koa-bodyparser": "^4",
-        "@types/koa-router": "^7.4.4",
+        "@types/koa__router": "^12.0.0",
+        "@types/koa-bodyparser": "^4.3.10",
         "@types/prettier": "^2",
         "@types/supertest": "^2.0.12",
         "eslint": "^8.42.0",
@@ -43,9 +43,9 @@
         "yup": "^1.2.0"
       },
       "peerDependencies": {
+        "@koa/router": ">=8.0.0",
         "joi": ">=16.0.0",
         "koa": "*",
-        "koa-router": ">=6.0.0",
         "yup": "*"
       },
       "peerDependenciesMeta": {
@@ -1259,6 +1259,46 @@
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
       "dev": true
     },
+    "node_modules/@koa/router": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@koa/router/-/router-12.0.0.tgz",
+      "integrity": "sha512-cnnxeKHXlt7XARJptflGURdJaO+ITpNkOHmQu7NHmCoRinPbyvFzce/EG/E8Zy81yQ1W9MoSdtklc3nyaDReUw==",
+      "peer": true,
+      "dependencies": {
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "methods": "^1.1.2",
+        "path-to-regexp": "^6.2.1"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@koa/router/node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "peer": true,
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@koa/router/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1602,6 +1642,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/koa__router": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@types/koa__router/-/koa__router-12.0.0.tgz",
+      "integrity": "sha512-S6eHyZyoWCZLNHyy8j0sMW85cPrpByCbGGU2/BO4IzGiI87aHJ92lZh4E9xfsM9DcbCT469/OIqyC0sSJXSIBQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/koa": "*"
+      }
+    },
     "node_modules/@types/koa-bodyparser": {
       "version": "4.3.10",
       "resolved": "https://registry.npmjs.org/@types/koa-bodyparser/-/koa-bodyparser-4.3.10.tgz",
@@ -1615,15 +1664,6 @@
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.5.tgz",
       "integrity": "sha512-B8nG/OoE1ORZqCkBVsup/AKcvjdgoHnfi4pZMn5UwAPCbhk/96xyv284eBYW8JlQbQ7zDmnpFr68I/40mFoIBQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/koa": "*"
-      }
-    },
-    "node_modules/@types/koa-router": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@types/koa-router/-/koa-router-7.4.4.tgz",
-      "integrity": "sha512-3dHlZ6CkhgcWeF6wafEUvyyqjWYfKmev3vy1PtOmr0mBc3wpXPU5E8fBBd4YQo5bRpHPfmwC5yDaX7s4jhIN6A==",
       "dev": true,
       "dependencies": {
         "@types/koa": "*"
@@ -5477,46 +5517,6 @@
       },
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/koa-router": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/koa-router/-/koa-router-12.0.0.tgz",
-      "integrity": "sha512-zGrdiXygGYW8WvrzeGsHZvKnHs4DzyGoqJ9a8iHlRkiwuEAOAPyI27//OlhoWdgFAEIM3qbUgr0KCuRaP/TCag==",
-      "peer": true,
-      "dependencies": {
-        "http-errors": "^2.0.0",
-        "koa-compose": "^4.1.0",
-        "methods": "^1.1.2",
-        "path-to-regexp": "^6.2.1"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/koa-router/node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-      "peer": true,
-      "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/koa-router/node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/leven": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "joi-to-swagger": "^6.2.0",
         "openapi3-ts": "^4.1.2"
       },
       "devDependencies": {
@@ -730,14 +731,12 @@
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
-      "optional": true
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
     },
     "node_modules/@hapi/topo": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
       "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
-      "optional": true,
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
       }
@@ -1319,7 +1318,6 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
       "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
-      "optional": true,
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
       }
@@ -1327,14 +1325,12 @@
     "node_modules/@sideway/formula": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
-      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
-      "optional": true
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
     },
     "node_modules/@sideway/pinpoint": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
-      "optional": true
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.25.24",
@@ -5314,13 +5310,26 @@
       "version": "17.9.2",
       "resolved": "https://registry.npmjs.org/joi/-/joi-17.9.2.tgz",
       "integrity": "sha512-Itk/r+V4Dx0V3c7RLFdRh12IOjySm2/WGPMubBT92cQvRfYZhPM2W0hZlctjj72iES8jsRCwp7S/cRmWBnJ4nw==",
-      "optional": true,
       "dependencies": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0",
         "@sideway/address": "^4.1.3",
         "@sideway/formula": "^3.0.1",
         "@sideway/pinpoint": "^2.0.0"
+      }
+    },
+    "node_modules/joi-to-swagger": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/joi-to-swagger/-/joi-to-swagger-6.2.0.tgz",
+      "integrity": "sha512-gwfIr1TsbbvZWozB/sFqiD7POFcXeaLKp6QJKGFkVgdom2ie/4f75QQAanZc/Wlbnyk66e6kTZXO28i6pN3oQA==",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "joi": ">=17.1.1"
       }
     },
     "node_modules/js-tokens": {
@@ -5552,6 +5561,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "koa-x-router",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "koa-x-router",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "Apache-2.0",
       "dependencies": {
         "joi-to-swagger": "^6.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "koa-x-router",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "koa-x-router",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "Apache-2.0",
       "dependencies": {
         "joi-to-swagger": "^6.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "koa-x-router",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "koa-x-router",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "Apache-2.0",
       "dependencies": {
         "joi-to-swagger": "^6.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
-  "name": "@ecubelabs/koa-x-router",
+  "name": "koa-x-router",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@ecubelabs/koa-x-router",
+      "name": "koa-x-router",
       "version": "0.0.1",
-      "license": "MIT",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "openapi3-ts": "^4.1.2"
+      },
       "devDependencies": {
         "@ecubelabs/prettier-config": "^0.0.8",
         "@ecubelabs/tsconfig": "^1.0.0",
@@ -5886,6 +5889,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi3-ts": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.1.2.tgz",
+      "integrity": "sha512-B7gOkwsYMZO7BZXwJzXCuVagym2xhqsrilVvV0dnq2Di4+iLUXKVX9gOK23ZqaAHZOwABXN0QTdW8QnkUTX6DA==",
+      "dependencies": {
+        "yaml": "^2.2.2"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -7424,6 +7435,14 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
+    },
+    "node_modules/yaml": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
+      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "koa-x-router",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "koa-x-router",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "joi-to-swagger": "^6.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "koa-x-router",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "koa-x-router",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "joi-to-swagger": "^6.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "koa-x-router",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "koa-x-router",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "Apache-2.0",
       "dependencies": {
         "joi-to-swagger": "^6.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,20 +39,15 @@
         "typescript": "^4.9.5"
       },
       "optionalDependencies": {
-        "joi": "^17.9.2",
-        "yup": "^1.2.0"
+        "joi": "^17.9.2"
       },
       "peerDependencies": {
         "@koa/router": ">=8.0.0",
         "joi": ">=16.0.0",
-        "koa": "*",
-        "yup": "*"
+        "koa": "*"
       },
       "peerDependenciesMeta": {
         "joi": {
-          "optional": true
-        },
-        "yup": {
           "optional": true
         }
       }
@@ -6220,12 +6215,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/property-expr": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.5.tgz",
-      "integrity": "sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA==",
-      "optional": true
-    },
     "node_modules/punycode": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
@@ -6904,12 +6893,6 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
-    "node_modules/tiny-case": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
-      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
-      "optional": true
-    },
     "node_modules/titleize": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
@@ -6956,12 +6939,6 @@
       "engines": {
         "node": ">=0.6"
       }
-    },
-    "node_modules/toposort": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
-      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
-      "optional": true
     },
     "node_modules/ts-jest": {
       "version": "29.1.0",
@@ -7510,30 +7487,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yup": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/yup/-/yup-1.2.0.tgz",
-      "integrity": "sha512-PPqYKSAXjpRCgLgLKVGPA33v5c/WgEx3wi6NFjIiegz90zSwyMpvTFp/uGcVnnbx6to28pgnzp/q8ih3QRjLMQ==",
-      "optional": true,
-      "dependencies": {
-        "property-expr": "^2.0.5",
-        "tiny-case": "^1.0.3",
-        "toposort": "^2.0.2",
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/yup/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "optional": true,
-      "engines": {
-        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -58,20 +58,15 @@
     "typescript": "^4.9.5"
   },
   "optionalDependencies": {
-    "joi": "^17.9.2",
-    "yup": "^1.2.0"
+    "joi": "^17.9.2"
   },
   "peerDependencies": {
     "@koa/router": ">=8.0.0",
     "joi": ">=16.0.0",
-    "koa": "*",
-    "yup": "*"
+    "koa": "*"
   },
   "peerDependenciesMeta": {
     "joi": {
-      "optional": true
-    },
-    "yup": {
       "optional": true
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-x-router",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "`koa-x-router` is a library that extends the functionality of `koa-router` by providing validation and automatic API documentation features. It simplifies the process of defining routes, validating request data, and generating API documentation.",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-x-router",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "`koa-x-router` is a library that extends the functionality of `koa-router` by providing validation and automatic API documentation features. It simplifies the process of defining routes, validating request data, and generating API documentation.",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "@types/eslint": "^8",
     "@types/jest": "^29.5.2",
     "@types/koa": "^2.13.6",
-    "@types/koa-bodyparser": "^4",
-    "@types/koa-router": "^7.4.4",
+    "@types/koa__router": "^12.0.0",
+    "@types/koa-bodyparser": "^4.3.10",
     "@types/prettier": "^2",
     "@types/supertest": "^2.0.12",
     "eslint": "^8.42.0",
@@ -52,9 +52,9 @@
     "yup": "^1.2.0"
   },
   "peerDependencies": {
+    "@koa/router": ">=8.0.0",
     "joi": ">=16.0.0",
     "koa": "*",
-    "koa-router": ">=6.0.0",
     "yup": "*"
   },
   "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-x-router",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "`koa-x-router` is a library that extends the functionality of `koa-router` by providing validation and automatic API documentation features. It simplifies the process of defining routes, validating request data, and generating API documentation.",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-x-router",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "`koa-x-router` is a library that extends the functionality of `koa-router` by providing validation and automatic API documentation features. It simplifies the process of defining routes, validating request data, and generating API documentation.",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     }
   },
   "dependencies": {
+    "joi-to-swagger": "^6.2.0",
     "openapi3-ts": "^4.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,17 @@
     "package.json",
     "README.md"
   ],
+  "keywords": [
+    "koa",
+    "router",
+    "validation",
+    "documentation",
+    "openapi",
+    "swagger",
+    "joi",
+    "yup",
+    "ecubelabs"
+  ],
   "repository": {
     "type": "git",
     "url": "git@github.com:Ecube-Labs/koa-x-router.git"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "git@github.com:Ecube-Labs/koa-x-router.git"
   },
   "author": "Ecube Labs Co., Ltd.",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "devDependencies": {
     "@ecubelabs/prettier-config": "^0.0.8",
     "@ecubelabs/tsconfig": "^1.0.0",
@@ -64,5 +64,8 @@
     "yup": {
       "optional": true
     }
+  },
+  "dependencies": {
+    "openapi3-ts": "^4.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-x-router",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "`koa-x-router` is a library that extends the functionality of `koa-router` by providing validation and automatic API documentation features. It simplifies the process of defining routes, validating request data, and generating API documentation.",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "test": "jest",
     "build": "tsc",
     "prepublish": "npm run build",
-    "prepublishOnly": "npm run build",
-    "publish": "npm publish --access public"
+    "prepublishOnly": "npm run build"
   },
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-x-router",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "`koa-x-router` is a library that extends the functionality of `koa-router` by providing validation and automatic API documentation features. It simplifies the process of defining routes, validating request data, and generating API documentation.",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-x-router",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "`koa-x-router` is a library that extends the functionality of `koa-router` by providing validation and automatic API documentation features. It simplifies the process of defining routes, validating request data, and generating API documentation.",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -58,11 +58,11 @@
     "typescript": "^4.9.5"
   },
   "optionalDependencies": {
-    "joi": "^17.9.2"
+    "joi": ">=17.0.0"
   },
   "peerDependencies": {
     "@koa/router": ">=8.0.0",
-    "joi": ">=16.0.0",
+    "joi": ">=17.0.0",
     "koa": "*"
   },
   "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-x-router",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "`koa-x-router` is a library that extends the functionality of `koa-router` by providing validation and automatic API documentation features. It simplifies the process of defining routes, validating request data, and generating API documentation.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./libs";

--- a/src/libs/JoiAdaptor.ts
+++ b/src/libs/JoiAdaptor.ts
@@ -1,0 +1,135 @@
+/**
+ * 어댑터 인터페이스에 맞춰 Joi를 이용해 Validation을 수행할수 있게 하는 구현체
+ */
+import Joi from "joi";
+import { SchemaObject, SchemaObjectType } from "openapi3-ts/oas31";
+import { XRouterAdaptor } from "./Router";
+
+export const JoiAdaptor: XRouterAdaptor = {
+  name: "joi",
+
+  isCompatibleSchema(schemaLike) {
+    try {
+      if (Joi.isSchema(schemaLike)) {
+        return true;
+      }
+    } catch {
+      return false;
+    }
+
+    try {
+      if (Joi.isSchema(Joi.object(schemaLike))) {
+        return true;
+      }
+    } catch {
+      return false;
+    }
+
+    return false;
+  },
+
+  async validate(schemaLike, data) {
+    const schema = Joi.isSchema(schemaLike)
+      ? schemaLike
+      : Joi.object(schemaLike);
+
+    await schema.validateAsync(data);
+  },
+
+  schemaToOpenApiSchema(schemaLike) {
+    const schema = Joi.isSchema(schemaLike)
+      ? schemaLike
+      : Joi.object(schemaLike);
+
+    return convertJoiSchemaToOpenApi(schema as Joi.ObjectSchema);
+  },
+};
+
+// Joi 스키마를 OpenAPI Spec으로 변환하는 함수
+function convertJoiSchemaToOpenApi(schema: Joi.ObjectSchema): SchemaObject {
+  const openapiSchema: SchemaObject = {
+    type: "object",
+    properties: {},
+    required: [],
+  };
+
+  const joiKeys = Object.keys(schema.describe().keys);
+  for (const key of joiKeys) {
+    const joiSchema = schema.extract(key);
+    const openapiProperty: SchemaObject = {
+      ...convertJoiTypeToOpenApi(joiSchema),
+      description: joiSchema.describe().description,
+    };
+
+    if (joiSchema._flags.presence === "required") {
+      openapiSchema.required!.push(key);
+    }
+
+    openapiSchema.properties![key] = openapiProperty;
+  }
+
+  return openapiSchema;
+}
+
+// Joi 데이터 유형을 OpenAPI Spec 데이터 유형으로 변환하는 함수
+function convertJoiTypeToOpenApi(schema: Joi.Schema): Partial<SchemaObject> {
+  let type: SchemaObjectType | undefined;
+  let format:
+    | "int32"
+    | "int64"
+    | "float"
+    | "double"
+    | "byte"
+    | "binary"
+    | "date"
+    | "date-time"
+    | "password"
+    | string
+    | undefined;
+
+  if (schema.type === "string") {
+    type = "string";
+    if (schema._flags.insensitive) {
+      format = "insensitive";
+    } else if (schema._flags.email) {
+      format = "email";
+      // @ts-ignore
+    } else if (schema._valids?.has("isoDate")) {
+      format = "date-time";
+    }
+  } else if (schema.type === "number") {
+    type = "number";
+    if (schema._flags.integer) {
+      format = "int32";
+      // @ts-ignore
+    } else if (schema._valids?.has("float")) {
+      format = "float";
+    } else {
+      format = "double";
+    }
+  } else if (schema.type === "date") {
+    type = "string";
+    format = "date";
+  } else if (schema.type === "boolean") {
+    type = "boolean";
+  } else if (schema.type === "array") {
+    type = "array";
+    const itemsSchema = (schema as Joi.ArraySchema).$_terms.items[0];
+    return {
+      type,
+      items: convertJoiTypeToOpenApi(itemsSchema),
+    };
+  } else if (schema.type === "object") {
+    type = "object";
+    return {
+      type,
+      properties: convertJoiSchemaToOpenApi(schema as Joi.ObjectSchema)
+        .properties,
+    };
+  }
+
+  return {
+    type,
+    format,
+  };
+}

--- a/src/libs/JoiAdaptor.ts
+++ b/src/libs/JoiAdaptor.ts
@@ -33,7 +33,7 @@ export const JoiAdaptor: XRouterAdaptor = {
       ? schemaLike
       : Joi.object(schemaLike);
 
-    await schema.validateAsync(data);
+    return await schema.validateAsync(data);
   },
 
   schemaToOpenApiSchema(schemaLike) {

--- a/src/libs/JoiAdaptor.ts
+++ b/src/libs/JoiAdaptor.ts
@@ -2,7 +2,7 @@
  * 어댑터 인터페이스에 맞춰 Joi를 이용해 Validation을 수행할수 있게 하는 구현체
  */
 import Joi from "joi";
-import { SchemaObject, SchemaObjectType } from "openapi3-ts/oas31";
+import j2s from "joi-to-swagger";
 import { XRouterAdaptor } from "./Router";
 
 export const JoiAdaptor: XRouterAdaptor = {
@@ -41,95 +41,6 @@ export const JoiAdaptor: XRouterAdaptor = {
       ? schemaLike
       : Joi.object(schemaLike);
 
-    return convertJoiSchemaToOpenApi(schema as Joi.ObjectSchema);
+    return j2s(schema).swagger;
   },
 };
-
-// Joi 스키마를 OpenAPI Spec으로 변환하는 함수
-function convertJoiSchemaToOpenApi(schema: Joi.ObjectSchema): SchemaObject {
-  const openapiSchema: SchemaObject = {
-    type: "object",
-    properties: {},
-    required: [],
-  };
-
-  const joiKeys = Object.keys(schema.describe().keys);
-  for (const key of joiKeys) {
-    const joiSchema = schema.extract(key);
-    const openapiProperty: SchemaObject = {
-      ...convertJoiTypeToOpenApi(joiSchema),
-      description: joiSchema.describe().description,
-    };
-
-    if (joiSchema._flags.presence === "required") {
-      openapiSchema.required!.push(key);
-    }
-
-    openapiSchema.properties![key] = openapiProperty;
-  }
-
-  return openapiSchema;
-}
-
-// Joi 데이터 유형을 OpenAPI Spec 데이터 유형으로 변환하는 함수
-function convertJoiTypeToOpenApi(schema: Joi.Schema): Partial<SchemaObject> {
-  let type: SchemaObjectType | undefined;
-  let format:
-    | "int32"
-    | "int64"
-    | "float"
-    | "double"
-    | "byte"
-    | "binary"
-    | "date"
-    | "date-time"
-    | "password"
-    | string
-    | undefined;
-
-  if (schema.type === "string") {
-    type = "string";
-    if (schema._flags.insensitive) {
-      format = "insensitive";
-    } else if (schema._flags.email) {
-      format = "email";
-      // @ts-ignore
-    } else if (schema._valids?.has("isoDate")) {
-      format = "date-time";
-    }
-  } else if (schema.type === "number") {
-    type = "number";
-    if (schema._flags.integer) {
-      format = "int32";
-      // @ts-ignore
-    } else if (schema._valids?.has("float")) {
-      format = "float";
-    } else {
-      format = "double";
-    }
-  } else if (schema.type === "date") {
-    type = "string";
-    format = "date";
-  } else if (schema.type === "boolean") {
-    type = "boolean";
-  } else if (schema.type === "array") {
-    type = "array";
-    const itemsSchema = (schema as Joi.ArraySchema).$_terms.items[0];
-    return {
-      type,
-      items: convertJoiTypeToOpenApi(itemsSchema),
-    };
-  } else if (schema.type === "object") {
-    type = "object";
-    return {
-      type,
-      properties: convertJoiSchemaToOpenApi(schema as Joi.ObjectSchema)
-        .properties,
-    };
-  }
-
-  return {
-    type,
-    format,
-  };
-}

--- a/src/libs/Router.test.ts
+++ b/src/libs/Router.test.ts
@@ -320,6 +320,15 @@ describe("koa-x-router API work with Joi", () => {
           get: {
             summary: "Hello World",
             description: "this is description",
+            parameters: [
+              {
+                in: "query",
+                name: "name",
+                schema: {
+                  type: "string",
+                },
+              },
+            ],
             responses: { "200": { description: "Success" } },
           },
         },
@@ -487,6 +496,9 @@ describe("koa-x-router API work with Joi", () => {
           },
         },
         validate: {
+          params: Joi.object({
+            id: Joi.number().positive().integer().required(),
+          }),
           output: {
             200: Joi.object({
               name: Joi.string().required(),
@@ -521,6 +533,15 @@ describe("koa-x-router API work with Joi", () => {
           get: {
             summary: "Hello World",
             description: "this is description",
+            parameters: [
+              {
+                in: "query",
+                name: "name",
+                schema: {
+                  type: "string",
+                },
+              },
+            ],
             responses: { "200": { description: "Success" } },
           },
         },
@@ -568,6 +589,16 @@ describe("koa-x-router API work with Joi", () => {
         "/child2/users/:id": {
           get: {
             summary: "Details User",
+            parameters: [
+              {
+                in: "path",
+                name: "id",
+                schema: {
+                  minimum: 1,
+                  type: "integer",
+                },
+              },
+            ],
             responses: {
               "200": {
                 description: "Success",

--- a/src/libs/Router.test.ts
+++ b/src/libs/Router.test.ts
@@ -160,9 +160,11 @@ describe("koa-x-router API work with Joi", () => {
         path: "/output1",
         validate: {
           output: {
-            200: Joi.object({
-              id: Joi.valid("tim", "charlie").required(),
-            }),
+            200: {
+              body: Joi.object({
+                id: Joi.valid("tim", "charlie").required(),
+              }),
+            },
           },
         },
         handler: async (ctx) => {
@@ -176,10 +178,14 @@ describe("koa-x-router API work with Joi", () => {
         path: "/output2",
         validate: {
           output: {
-            200: Joi.object({
-              id: Joi.valid("tim", "charlie").required(),
-            }),
-            201: Joi.string().valid("created~~").required(),
+            200: {
+              body: Joi.object({
+                id: Joi.valid("tim", "charlie").required(),
+              }),
+            },
+            201: {
+              body: Joi.string().valid("created~~").required(),
+            },
           },
         },
         handler: async (ctx) => {
@@ -296,7 +302,7 @@ describe("koa-x-router API work with Joi", () => {
     });
   });
 
-  it("should be validate ctx.params and cast value inject", async () => {
+  it("should be validate ctx.request.params and cast value inject", async () => {
     const app = getApp();
     const router = new Router({
       adaptors: [JoiAdaptor],
@@ -400,14 +406,16 @@ describe("koa-x-router API work with Joi", () => {
         path: "/output",
         validate: {
           output: {
-            200: Joi.object({
-              id: Joi.number().required(),
-              collection: Joi.array().items(
-                Joi.object({
-                  num: Joi.number().required(),
-                })
-              ),
-            }).options({ stripUnknown: true }),
+            200: {
+              body: Joi.object({
+                id: Joi.number().required(),
+                collection: Joi.array().items(
+                  Joi.object({
+                    num: Joi.number().required(),
+                  })
+                ),
+              }).options({ stripUnknown: true }),
+            },
           },
         },
         handler: async (ctx) => {
@@ -498,12 +506,14 @@ describe("koa-x-router API work with Joi", () => {
         },
         validate: {
           output: {
-            200: Joi.array().items(
-              Joi.object({
-                name: Joi.string().required(),
-                age: Joi.number().required(),
-              })
-            ),
+            200: {
+              body: Joi.array().items(
+                Joi.object({
+                  name: Joi.string().required(),
+                  age: Joi.number().required(),
+                })
+              ),
+            },
           },
         },
         handler: async (ctx) => {
@@ -520,13 +530,17 @@ describe("koa-x-router API work with Joi", () => {
         },
         validate: {
           output: {
-            200: Joi.object({
-              name: Joi.string().required(),
-              age: Joi.number().required(),
-            }),
-            404: Joi.object({
-              message: Joi.string().required(),
-            }).description("User not found"),
+            200: {
+              body: Joi.object({
+                name: Joi.string().required(),
+                age: Joi.number().required(),
+              }),
+            },
+            404: {
+              body: Joi.object({
+                message: Joi.string().required(),
+              }).description("User not found"),
+            },
           },
         },
         handler: async (ctx) => {
@@ -703,12 +717,14 @@ describe("koa-x-router API work with Joi", () => {
         },
         validate: {
           output: {
-            200: Joi.array().items(
-              Joi.object({
-                name: Joi.string().required(),
-                age: Joi.number().required(),
-              })
-            ),
+            200: {
+              body: Joi.array().items(
+                Joi.object({
+                  name: Joi.string().required(),
+                  age: Joi.number().required(),
+                })
+              ),
+            },
           },
         },
         handler: async (ctx) => {
@@ -730,13 +746,17 @@ describe("koa-x-router API work with Joi", () => {
             id: Joi.number().positive().integer().required(),
           }),
           output: {
-            200: Joi.object({
-              name: Joi.string().required(),
-              age: Joi.number().required(),
-            }),
-            404: Joi.object({
-              message: Joi.string().required(),
-            }).description("User not found"),
+            200: {
+              body: Joi.object({
+                name: Joi.string().required(),
+                age: Joi.number().required(),
+              }),
+            },
+            404: {
+              body: Joi.object({
+                message: Joi.string().required(),
+              }).description("User not found"),
+            },
           },
         },
         handler: async (ctx) => {
@@ -928,12 +948,14 @@ describe("koa-x-router API work with Joi", () => {
         },
         validate: {
           output: {
-            200: Joi.array().items(
-              Joi.object({
-                name: Joi.string().required(),
-                age: Joi.number().required(),
-              })
-            ),
+            200: {
+              body: Joi.array().items(
+                Joi.object({
+                  name: Joi.string().required(),
+                  age: Joi.number().required(),
+                })
+              ),
+            },
           },
         },
         handler: async (ctx) => {
@@ -955,13 +977,17 @@ describe("koa-x-router API work with Joi", () => {
             id: Joi.number().positive().integer().required(),
           }),
           output: {
-            200: Joi.object({
-              name: Joi.string().required(),
-              age: Joi.number().required(),
-            }),
-            404: Joi.object({
-              message: Joi.string().required(),
-            }).description("User not found"),
+            200: {
+              body: Joi.object({
+                name: Joi.string().required(),
+                age: Joi.number().required(),
+              }),
+            },
+            404: {
+              body: Joi.object({
+                message: Joi.string().required(),
+              }).description("User not found"),
+            },
           },
         },
         handler: async (ctx) => {

--- a/src/libs/Router.test.ts
+++ b/src/libs/Router.test.ts
@@ -1,0 +1,351 @@
+import Joi from "joi";
+import request from "supertest";
+import koaBodyParser from "koa-bodyparser";
+import { getApp } from "../../test/app";
+import { JoiAdaptor, Router } from "./";
+
+describe("koa-router API", () => {
+  it("should be defined", () => {
+    expect(Router).toBeDefined();
+  });
+
+  it("should be able to create instance", () => {
+    const router = new Router();
+    expect(router).toBeDefined();
+  });
+
+  it("should be work with koa app", async () => {
+    const app = getApp();
+    const router = new Router();
+    app.use(router.routes());
+
+    router.get("/", async (ctx) => {
+      ctx.body = "Hello World";
+    });
+
+    const response = await request(app.callback()).get("/");
+    expect(response.status).toBe(200);
+    expect(response.text).toBe("Hello World");
+  });
+
+  it("should be work with koa app to create instance with options", async () => {
+    const app = getApp();
+    const router = new Router({ prefix: "/api" });
+    app.use(router.routes());
+
+    router.get("/path", async (ctx) => {
+      ctx.body = "Hello World";
+    });
+
+    const response = await request(app.callback()).get("/api/path");
+    expect(response.status).toBe(200);
+    expect(response.text).toBe("Hello World");
+  });
+});
+
+describe("koa-x-router API work with Joi", () => {
+  it("should be define validate schema", async () => {
+    const app = getApp();
+    const router = new Router({
+      adaptors: [JoiAdaptor],
+    });
+    app.use(router.routes());
+
+    router.add({
+      method: "get",
+      path: "/",
+      validate: {
+        query: Joi.object({
+          name: Joi.string(),
+        }),
+      },
+      handler: async (ctx) => {
+        ctx.body = `Hello World, ${ctx.query.name}`;
+      },
+    });
+
+    const [layer] = router.stack;
+
+    expect(layer.path).toBe("/");
+    expect(JSON.stringify(layer.opts.validate?.query)).toEqual(
+      JSON.stringify(
+        Joi.object({
+          name: Joi.string(),
+        })
+      )
+    );
+
+    const response = await request(app.callback()).get("/?name=tim");
+    expect(response.status).toBe(200);
+    expect(response.text).toBe("Hello World, tim");
+  });
+
+  it("throw error when empty adaptor", async () => {
+    const router = new Router();
+
+    expect(() => {
+      router.add({
+        method: "get",
+        path: "/",
+        validate: {
+          query: Joi.object({
+            name: "string",
+          }),
+        },
+        handler: async (ctx) => {
+          ctx.body = "Hello World";
+        },
+      });
+    }).toThrowError(/^Not found compatible adaptor for schema/g);
+  });
+
+  it("throw error when invalid data of schema", async () => {
+    const app = getApp();
+    const router = new Router({
+      adaptors: [JoiAdaptor],
+    });
+    app.use(koaBodyParser()).use(router.routes());
+
+    router.add([
+      {
+        method: "get",
+        path: "/query",
+        validate: {
+          query: Joi.object({
+            name: Joi.string().required(),
+          }),
+        },
+        handler: async (ctx) => {
+          ctx.body = `Hello World, ${ctx.query.name}`;
+        },
+      },
+      {
+        method: "post",
+        path: "/body",
+        validate: {
+          body: Joi.object({
+            age: Joi.number(),
+          }),
+        },
+        handler: async (ctx) => {
+          ctx.body = `Hello World`;
+        },
+      },
+      {
+        method: "get",
+        path: "/header",
+        validate: {
+          header: Joi.object({
+            authorization: Joi.string().required(),
+          }),
+        },
+        handler: async (ctx) => {
+          ctx.body = `Hello World`;
+        },
+      },
+      {
+        method: "get",
+        path: "/params/:id",
+        validate: {
+          params: Joi.object({
+            id: Joi.valid("tim", "charlie").required(),
+          }),
+        },
+        handler: async (ctx) => {
+          ctx.body = `Hello World`;
+        },
+      },
+      {
+        method: "get",
+        path: "/output1",
+        validate: {
+          output: {
+            200: Joi.object({
+              id: Joi.valid("tim", "charlie").required(),
+            }),
+          },
+        },
+        handler: async (ctx) => {
+          ctx.body = {
+            id: "ben",
+          };
+        },
+      },
+      {
+        method: "get",
+        path: "/output2",
+        validate: {
+          output: {
+            200: Joi.object({
+              id: Joi.valid("tim", "charlie").required(),
+            }),
+            201: Joi.string().valid("created~~").required(),
+          },
+        },
+        handler: async (ctx) => {
+          ctx.status = 201;
+          ctx.body = "created^^";
+        },
+      },
+    ]);
+
+    const response1 = await request(app.callback()).get("/query");
+    expect(response1.status).toBe(400);
+    expect(response1.text).toBe('"name" is required');
+
+    const response2 = await request(app.callback()).post("/body").send({
+      age: "dasdas",
+    });
+    expect(response2.status).toBe(400);
+    expect(response2.text).toBe('"age" must be a number');
+
+    const response3 = await request(app.callback()).get("/header");
+    expect(response3.status).toBe(400);
+    expect(response3.text).toBe('"authorization" is required');
+
+    const response4 = await request(app.callback()).get("/params/ben");
+    expect(response4.status).toBe(400);
+    expect(response4.text).toBe('"id" must be one of [tim, charlie]');
+
+    const response5 = await request(app.callback()).get("/output1");
+    expect(response5.status).toBe(400);
+    expect(response5.text).toBe('"id" must be one of [tim, charlie]');
+
+    const response6 = await request(app.callback()).get("/output2");
+    expect(response6.status).toBe(400);
+    expect(response6.text).toBe('"value" must be [created~~]');
+  });
+
+  it("Generate OpenAPI Spec from routes", async () => {
+    const router = new Router({
+      adaptors: [JoiAdaptor],
+    });
+
+    router.add([
+      {
+        method: "get",
+        path: "/",
+        meta: {
+          document: {
+            summary: "Hello World",
+            description: "this is description",
+          },
+        },
+        validate: {
+          query: Joi.object({
+            name: Joi.string(),
+          }),
+        },
+        handler: async (ctx) => {
+          ctx.body = `Hello World, ${ctx.query.name}`;
+        },
+      },
+      {
+        method: "post",
+        path: "/users",
+        meta: {
+          document: {
+            summary: "Create User",
+          },
+        },
+        validate: {
+          body: Joi.object({
+            name: Joi.string(),
+          }),
+        },
+        handler: async (ctx) => {
+          ctx.status = 201;
+          ctx.body = `Created`;
+        },
+      },
+      {
+        method: "get",
+        path: "/users",
+        meta: {
+          document: {
+            summary: "List Users",
+          },
+        },
+        validate: {
+          output: {
+            200: Joi.array().items(
+              Joi.object({
+                name: Joi.string().required(),
+                age: Joi.number().required(),
+              })
+            ),
+          },
+        },
+        handler: async (ctx) => {
+          ctx.body = [];
+        },
+      },
+      {
+        method: "get",
+        path: "/users/:id",
+        meta: {
+          document: {
+            summary: "Details User",
+          },
+        },
+        validate: {
+          output: {
+            200: Joi.object({
+              name: Joi.string().required(),
+              age: Joi.number().required(),
+            }),
+          },
+        },
+        handler: async (ctx) => {
+          ctx.body = {};
+        },
+      },
+    ]);
+
+    const spec = router.generateOpenApiSpecJson({
+      info: {
+        title: "koa-x-router",
+        version: "1.0.0",
+      },
+    });
+
+    expect(spec).toEqual(
+      JSON.stringify({
+        openapi: "3.1.0",
+        info: {
+          title: "koa-x-router",
+          version: "1.0.0",
+        },
+        paths: {
+          "/": {
+            get: {
+              summary: "Hello World",
+              description: "this is description",
+              responses: {},
+            },
+          },
+          "/users": {
+            post: {
+              summary: "Create User",
+              responses: {},
+            },
+            get: {
+              summary: "List Users",
+              responses: {},
+            },
+          },
+          "/users/:id": {
+            get: {
+              summary: "Details User",
+              responses: {},
+            },
+          },
+        },
+      })
+    );
+  });
+
+  // TODO: Nested router
+
+  // TODO: prefix
+});

--- a/src/libs/Router.test.ts
+++ b/src/libs/Router.test.ts
@@ -314,7 +314,7 @@ describe("koa-x-router API work with Joi", () => {
         },
         handler: async (ctx) => {
           ctx.body = {
-            params: ctx.params,
+            params: ctx.request.params,
           };
         },
       },

--- a/src/libs/Router.test.ts
+++ b/src/libs/Router.test.ts
@@ -294,6 +294,9 @@ describe("koa-x-router API work with Joi", () => {
               name: Joi.string().required(),
               age: Joi.number().required(),
             }),
+            404: Joi.object({
+              message: Joi.string().required(),
+            }).description("User not found"),
           },
         },
         handler: async (ctx) => {
@@ -312,32 +315,91 @@ describe("koa-x-router API work with Joi", () => {
     expect(spec).toEqual(
       JSON.stringify({
         openapi: "3.1.0",
-        info: {
-          title: "koa-x-router",
-          version: "1.0.0",
-        },
+        info: { title: "koa-x-router", version: "1.0.0" },
         paths: {
           "/": {
             get: {
               summary: "Hello World",
               description: "this is description",
-              responses: {},
+              responses: { "200": { description: "Success" } },
             },
           },
           "/users": {
             post: {
               summary: "Create User",
-              responses: {},
+              responses: { "200": { description: "Success" } },
+              requestBody: {
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      properties: { name: { type: "string" } },
+                      additionalProperties: false,
+                    },
+                  },
+                },
+              },
             },
             get: {
               summary: "List Users",
-              responses: {},
+              responses: {
+                "200": {
+                  description: "Success",
+                  content: {
+                    "application/json": {
+                      schema: {
+                        type: "array",
+                        items: {
+                          type: "object",
+                          properties: {
+                            name: { type: "string" },
+                            age: { type: "number", format: "float" },
+                          },
+                          required: ["name", "age"],
+                          additionalProperties: false,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
             },
           },
           "/users/:id": {
             get: {
               summary: "Details User",
-              responses: {},
+              responses: {
+                "200": {
+                  description: "Success",
+                  content: {
+                    "application/json": {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          name: { type: "string" },
+                          age: { type: "number", format: "float" },
+                        },
+                        required: ["name", "age"],
+                        additionalProperties: false,
+                      },
+                    },
+                  },
+                },
+                "404": {
+                  description: "User not found",
+                  content: {
+                    "application/json": {
+                      schema: {
+                        type: "object",
+                        properties: { message: { type: "string" } },
+                        required: ["message"],
+                        additionalProperties: false,
+                        description: "User not found",
+                      },
+                    },
+                  },
+                },
+              },
             },
           },
         },

--- a/src/libs/Router.ts
+++ b/src/libs/Router.ts
@@ -39,7 +39,7 @@ type SchemaMetadata = {
   [key: string]: any;
 };
 
-interface RouteLayerSpec<StateT = any, CustomT = {}> {
+export interface RouteLayerSpec<StateT = any, CustomT = {}> {
   method:
     | "get"
     | "post"

--- a/src/libs/Router.ts
+++ b/src/libs/Router.ts
@@ -39,7 +39,15 @@ type SchemaMetadata = {
 };
 
 interface RouteLayerSpec<StateT = any, CustomT = {}> {
-  method: "get" | "post" | "put" | "patch" | "delete";
+  method:
+    | "get"
+    | "post"
+    | "delete"
+    | "put"
+    | "options"
+    | "head"
+    | "patch"
+    | "trace";
   path: string;
   meta?: {
     // compatible for `koa-joi-router-docs`

--- a/src/libs/Router.ts
+++ b/src/libs/Router.ts
@@ -31,6 +31,16 @@ declare module "@koa/router" {
 
 export interface SchemaLike {}
 
+type SupportMethod =
+  | "get"
+  | "post"
+  | "delete"
+  | "put"
+  | "options"
+  | "head"
+  | "patch"
+  | "trace";
+
 type SchemaMetadata = {
   summary: string;
   description?: string;
@@ -40,15 +50,7 @@ type SchemaMetadata = {
 };
 
 export interface RouteLayerSpec<StateT = any, CustomT = {}> {
-  method:
-    | "get"
-    | "post"
-    | "delete"
-    | "put"
-    | "options"
-    | "head"
-    | "patch"
-    | "trace";
+  method: SupportMethod | Uppercase<SupportMethod>;
   path: string;
   meta?: {
     // compatible for `koa-joi-router-docs`
@@ -137,15 +139,7 @@ export class Router<StateT = any, CustomT = {}> extends KoaRouter<
             return;
 
           pathItem[
-            method.toLowerCase() as
-              | "get"
-              | "post"
-              | "delete"
-              | "put"
-              | "options"
-              | "head"
-              | "patch"
-              | "trace"
+            method.toLowerCase() as SupportMethod | Uppercase<SupportMethod>
           ] = {
             summary: docMetadata?.summary,
             description: docMetadata?.description,

--- a/src/libs/Router.ts
+++ b/src/libs/Router.ts
@@ -1,0 +1,316 @@
+import KoaRouter from "koa-router";
+import {
+  ComponentsObject,
+  ExternalDocumentationObject,
+  InfoObject,
+  OpenAPIObject,
+  OpenApiBuilder,
+  OperationObject,
+  PathItemObject,
+  PathsObject,
+  SchemaObject,
+  SecurityRequirementObject,
+  ServerObject,
+  TagObject,
+} from "openapi3-ts/oas31";
+
+declare module "koa-router" {
+  export interface ILayerOptions {
+    validate?: XRouterValidateProperties;
+  }
+
+  export interface Layer {
+    meta?: {
+      // compatible for `koa-joi-router-docs`
+      swagger?: SchemaMetadata; // === document
+      document?: SchemaMetadata; // === swagger
+    };
+  }
+}
+
+export interface SchemaLike {}
+
+type SchemaMetadata = {
+  summary: string;
+  description?: string;
+  tags?: string[];
+  deprecated?: boolean;
+  [key: string]: any;
+};
+
+interface RouteLayerSpec<StateT = any, CustomT = {}> {
+  method: "get" | "post" | "put" | "patch" | "delete";
+  path: string;
+  meta?: {
+    // compatible for `koa-joi-router-docs`
+    swagger?: SchemaMetadata; // === document
+    document?: SchemaMetadata; // === swagger
+  };
+  validate?: XRouterValidateProperties;
+  handler: KoaRouter.IMiddleware<StateT, CustomT>;
+}
+
+/**
+ * 공통 인터페이스를 기반으로 validation을 수행하는 koa-router 기반의 라우터
+ * 각 route handler의 validate.[header | query | params | body | output]에 대한 validation을 수행한다.
+ */
+export class Router<StateT = any, CustomT = {}> extends KoaRouter<
+  StateT,
+  CustomT
+> {
+  adaptors: Record<string, XRouterAdaptor>;
+
+  constructor({
+    adaptors,
+    ...pt
+  }: KoaRouter.IRouterOptions & { adaptors?: XRouterAdaptor[] } = {}) {
+    super(pt);
+
+    this.adaptors =
+      adaptors?.reduce(
+        (acc, adaptor) => ({
+          ...acc,
+          [adaptor.name]: adaptor,
+        }),
+        {}
+      ) || {};
+  }
+
+  add(
+    spec: RouteLayerSpec<StateT, CustomT> | RouteLayerSpec<StateT, CustomT>[]
+  ) {
+    const specs = Array.isArray(spec) ? spec : [spec];
+    specs.forEach((spec) => {
+      const { validate, meta } = spec;
+
+      const layer = super.register(spec.path, [spec.method], [spec.handler], {
+        name: spec.path,
+      });
+
+      layer.meta = meta;
+
+      this.registerValidator(layer, validate);
+    });
+  }
+
+  generateOpenApiSpecJson(metadata: {
+    info: InfoObject;
+    servers?: ServerObject[];
+    paths?: PathsObject;
+    components?: ComponentsObject;
+    security?: SecurityRequirementObject[];
+    tags?: TagObject[];
+    externalDocs?: ExternalDocumentationObject;
+    webhooks?: PathsObject;
+  }): string {
+    const builder = OpenApiBuilder.create({
+      openapi: "3.1.0",
+      ...metadata,
+    });
+
+    // TODO: generate openapi spec from routes
+    const paths = this.getRoutePaths(this.stack);
+    Object.entries(paths).forEach(([path, pathItem]) => {
+      builder.addPath(path, pathItem);
+    });
+
+    return builder.getSpecAsJson();
+  }
+
+  private getRoutePaths(stack: KoaRouter.Layer[]) {
+    const pathItemByPath: Record<string, PathItemObject> = {};
+    stack.forEach((layer) => {
+      if (layer.path && layer.methods) {
+        const pathItem: PathItemObject = pathItemByPath[layer.path] || {};
+
+        const docMetadata = layer.meta?.document || layer.meta?.swagger;
+        layer.methods.forEach((method) => {
+          if (layer.methods.length > 1 && method.toLowerCase() === "head")
+            return;
+
+          pathItem[
+            method.toLowerCase() as
+              | "get"
+              | "post"
+              | "delete"
+              | "put"
+              | "options"
+              | "head"
+              | "patch"
+              | "trace"
+          ] = {
+            summary: docMetadata?.summary,
+            description: docMetadata?.description,
+            deprecated: docMetadata?.deprecated,
+            tags: docMetadata?.tags,
+            responses: {},
+          };
+        });
+
+        pathItemByPath[layer.path] = pathItem;
+      }
+    });
+    return pathItemByPath;
+  }
+
+  private registerValidator(
+    layer: KoaRouter.Layer,
+    validate?: XRouterValidateProperties
+  ) {
+    if (validate) {
+      layer.opts.validate = validate;
+      if (layer.opts.validate.header) {
+        layer.opts.validate._headerAdaptor = this.getAdaptorFromSchema(
+          layer.opts.validate.header
+        );
+      }
+      if (layer.opts.validate.query) {
+        layer.opts.validate._queryAdaptor = this.getAdaptorFromSchema(
+          layer.opts.validate.query
+        );
+      }
+      if (layer.opts.validate.params) {
+        layer.opts.validate._paramsAdaptor = this.getAdaptorFromSchema(
+          layer.opts.validate.params
+        );
+      }
+      if (layer.opts.validate.body) {
+        layer.opts.validate._bodyAdaptor = this.getAdaptorFromSchema(
+          layer.opts.validate.body
+        );
+      }
+      if (layer.opts.validate.output) {
+        layer.opts.validate._outputAdaptor = this.getAdaptorFromSchema(
+          Object.values(layer.opts.validate.output)[0]
+        );
+      }
+
+      layer.stack.unshift(this.makeValidateMiddleware(layer));
+    }
+  }
+
+  private getAdaptorFromSchema(schema: any): XRouterAdaptor | undefined {
+    const adaptor = Object.values(this.adaptors).find((adaptor) =>
+      adaptor.isCompatibleSchema(schema)
+    );
+
+    if (!adaptor) {
+      throw new Error(
+        `Not found compatible adaptor for schema: ${JSON.stringify(schema)}`
+      );
+    }
+
+    return adaptor;
+  }
+
+  private makeValidateMiddleware(
+    layer: KoaRouter.Layer
+  ): KoaRouter.IMiddleware<any, any> {
+    return async (ctx, next) => {
+      const {
+        opts: { validate },
+      } = layer;
+      if (!validate) return await next();
+
+      const {
+        body,
+        _bodyAdaptor,
+        query,
+        _queryAdaptor,
+        header,
+        _headerAdaptor,
+        params,
+        _paramsAdaptor,
+        output,
+        _outputAdaptor,
+      } = validate;
+
+      const errorHandler = (err: any) => {
+        err.status = 400;
+        return ctx.throw(err);
+      };
+
+      await _headerAdaptor
+        ?.validate(header!, ctx.request.headers)
+        .catch(errorHandler);
+      await _paramsAdaptor
+        ?.validate(params!, ctx.request.params)
+        .catch(errorHandler);
+      await _queryAdaptor
+        ?.validate(query!, ctx.request.query)
+        .catch(errorHandler);
+      await _bodyAdaptor?.validate(body!, ctx.request.body).catch(errorHandler);
+
+      await next();
+
+      if (_outputAdaptor && output) {
+        const [_, outputSchema] =
+          Object.entries(output).find(([statusCodeRange]) =>
+            this.isIncludedStatusCodeRange(statusCodeRange, Number(ctx.status))
+          ) || [];
+
+        if (outputSchema) {
+          await _outputAdaptor
+            .validate(outputSchema, ctx.body)
+            .catch(errorHandler);
+        }
+      }
+    };
+  }
+
+  private isIncludedStatusCodeRange(
+    // ex) '200', '400-499', '500-599'
+    range: string,
+    statusCode: number
+  ) {
+    const [min, max] = range.split("-").map(Number);
+    if (!max) return statusCode === min;
+    return statusCode >= min && statusCode <= max;
+  }
+}
+
+interface XRouterValidateProperties {
+  header?: SchemaLike;
+  _headerAdaptor?: XRouterAdaptor; // Router에 route 추가할때 스키마 기반으로 추론하여 지정
+
+  query?: SchemaLike;
+  _queryAdaptor?: XRouterAdaptor; // Router에 route 추가할때 스키마 기반으로 추론하여 지정
+
+  params?: SchemaLike;
+  _paramsAdaptor?: XRouterAdaptor; // Router에 route 추가할때 스키마 기반으로 추론하여 지정
+
+  body?: SchemaLike;
+  _bodyAdaptor?: XRouterAdaptor; // Router에 route 추가할때 스키마 기반으로 추론하여 지정
+
+  /**
+   * @example { 200: { ... }, '400-499': { ... } }
+   */
+  output?: {
+    [statusCode: number | string]: SchemaLike;
+  };
+  _outputAdaptor?: XRouterAdaptor; // Router에 route 추가할때 스키마 기반으로 추론하여 지정
+
+  [key: string]: any;
+}
+
+export interface XRouterAdaptor {
+  /**
+   * Adaptor name
+   */
+  name: string;
+
+  /**
+   * This method checks whether the schema is compatible with the adaptor.
+   */
+  isCompatibleSchema(schemaLike: SchemaLike): boolean;
+
+  /**
+   * This method validates the data with the schema.
+   */
+  validate(schemaLike: SchemaLike, data: any): Promise<void>;
+
+  /**
+   * This method converts the schema to OpenAPI schema.
+   */
+  schemaToOpenApiSchema(schemaLike: SchemaLike): SchemaObject;
+}

--- a/src/libs/Router.ts
+++ b/src/libs/Router.ts
@@ -1,4 +1,4 @@
-import KoaRouter from "koa-router";
+import KoaRouter from "@koa/router";
 import {
   ComponentsObject,
   ExternalDocumentationObject,
@@ -14,8 +14,8 @@ import {
   TagObject,
 } from "openapi3-ts/oas31";
 
-declare module "koa-router" {
-  export interface ILayerOptions {
+declare module "@koa/router" {
+  export interface LayerOptions {
     validate?: XRouterValidateProperties;
   }
 
@@ -47,7 +47,7 @@ interface RouteLayerSpec<StateT = any, CustomT = {}> {
     document?: SchemaMetadata; // === swagger
   };
   validate?: XRouterValidateProperties;
-  handler: KoaRouter.IMiddleware<StateT, CustomT>;
+  handler: KoaRouter.Middleware<StateT, CustomT>;
 }
 
 /**
@@ -63,7 +63,7 @@ export class Router<StateT = any, CustomT = {}> extends KoaRouter<
   constructor({
     adaptors,
     ...pt
-  }: KoaRouter.IRouterOptions & { adaptors?: XRouterAdaptor[] } = {}) {
+  }: KoaRouter.RouterOptions & { adaptors?: XRouterAdaptor[] } = {}) {
     super(pt);
 
     this.adaptors =
@@ -253,7 +253,7 @@ export class Router<StateT = any, CustomT = {}> extends KoaRouter<
 
   private makeValidateMiddleware(
     layer: KoaRouter.Layer
-  ): KoaRouter.IMiddleware<any, any> {
+  ): KoaRouter.Middleware<any, any> {
     return async (ctx, next) => {
       const {
         opts: { validate },

--- a/src/libs/Router.ts
+++ b/src/libs/Router.ts
@@ -138,9 +138,7 @@ export class Router<StateT = any, CustomT = {}> extends KoaRouter<
           if (layer.methods.length > 1 && method.toLowerCase() === "head")
             return;
 
-          pathItem[
-            method.toLowerCase() as SupportMethod | Uppercase<SupportMethod>
-          ] = {
+          pathItem[method.toLowerCase() as SupportMethod] = {
             summary: docMetadata?.summary,
             description: docMetadata?.description,
             deprecated: docMetadata?.deprecated,

--- a/src/libs/index.ts
+++ b/src/libs/index.ts
@@ -1,0 +1,2 @@
+export * from "./JoiAdaptor";
+export * from "./Router";

--- a/test/app.ts
+++ b/test/app.ts
@@ -1,0 +1,3 @@
+import Koa from "koa";
+
+export const getApp = () => new Koa();


### PR DESCRIPTION
- Playground: https://stackblitz.com/edit/koa-x-router-demo?file=index.ts
- NPM: https://www.npmjs.com/package/koa-x-router

### `koa-joi-router` 와의 차별점
1. ~~`koa-x-router` 는 정의한 schema의 형식으로 캐스팅해 값을 변경해주는 동작 구현하지 않음~~ => 추가 구현.
    ex) query는 url에서 파싱하는 값이라 언제나 string으로만 다뤄지는데 validate.query에 number 형식으로 정의하면 캐스팅 된 값으로 넣어주는 동작이 `koa-joi-router` 에 존재 ([코드](https://github.com/koajs/joi-router/blob/d4e209d68e6109cd8e18684eef94040f025095cd/joi-router.js#L484-L497))
2. body parser를 내장하고 있지 않음. 따라서 body parser를 따로 사용해야 함. 역할을 분리하는 것이 좋다고 생각함.
    `koa-joi-router` 는 json/form/multipart body parser를 어설프게 내장하고 있음 ([코드](https://github.com/koajs/joi-router/blob/d4e209d68e6109cd8e18684eef94040f025095cd/joi-router.js#L300))
3. `@koa/router` , `joi`를 직접 의존하지 않고 호환되는 인터페이스 버전에 한해 Peer dependency로 의존. 프로젝트에서 비교적 자유롭게 버전 선택 가능
    - `@koa/router` 8 ~ 12까지 동작 확인 (`koa-router` 는 지원하지 않을 예정)
    - `joi` 는 17 외에 다 deprecated되어 확인 불가. (`@hapi/joi` 는 지원하지 않을 예정)
4. Validation 라이브러리는 `XRouterAdaptor` 인터페이스에 맞게 구현한다면 무엇이든 사용할 수 있음.
    현재는 `JoiAdaptor` 구현체만 제공되고 있음.

### `koa-joi-router-docs` 와의 차별점
1. Nested Router로 구성해도 문서를 생성하게 구현
    기존에는 미들웨어로 포함한 Router는 무시되고 직접 모든 `Router` 객체를 `SwaggerAPI` 객체에 추가해줘야 했음
2. Prefix를 지원.
    기존에는 prefix를 지정해도 포함되지 않고 path에 있는 값으로만 Open API Spec이 생성되는 문제가 있었음.

모든 차별점은 Playground에 직/간접적으로 코드에 표현되어 있으니 참고해주세요.