### PR TITLE
Create CJS type package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "koa-x-router",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "koa-x-router",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "license": "Apache-2.0",
       "dependencies": {
         "joi-to-swagger": "^6.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "koa-x-router",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "koa-x-router",
-      "version": "0.0.11",
+      "version": "0.0.12",
       "license": "Apache-2.0",
       "dependencies": {
         "joi-to-swagger": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-x-router",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "`koa-x-router` is a library that extends the functionality of `koa-router` by providing validation and automatic API documentation features. It simplifies the process of defining routes, validating request data, and generating API documentation.",
   "type": "module",
   "main": "dist/cjs/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-x-router",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "`koa-x-router` is a library that extends the functionality of `koa-router` by providing validation and automatic API documentation features. It simplifies the process of defining routes, validating request data, and generating API documentation.",
   "type": "module",
   "main": "dist/cjs/index.js",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "module": "dist/esm/index.js",
   "scripts": {
     "test": "jest",
-    "build": "rm -rf ./dist && tsc -p tsconfig.json && tsc -p tsconfig.cjs.json",
+    "build": "rm -rf ./dist && tsc -p tsconfig.json && tsc -p tsconfig.cjs.json && echo '{ \"type\": \"commonjs\" }' > dist/cjs/package.json",
     "prepublish": "npm run build",
     "prepublishOnly": "npm run build"
   },

--- a/src/libs/Router.ts
+++ b/src/libs/Router.ts
@@ -321,9 +321,7 @@ export class Router<StateT = any, CustomT = {}> extends KoaRouter<
     );
 
     if (!adaptor) {
-      throw new Error(
-        `Not found compatible adaptor for schema: ${JSON.stringify(schema)}`
-      );
+      throw new Error(`Not found compatible adaptor for schema: ${schema}`);
     }
 
     return adaptor;


### PR DESCRIPTION
```
Error [ERR_REQUIRE_ESM]: require() of ES Module <myproject>/node_modules/koa-x-router/dist/cjs/index.js from <router-imported-path>/index.ts not supported.
index.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
Instead rename index.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in <myproject>/node_modules/koa-x-router/package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).
```